### PR TITLE
update template to node-addon-api 1.1.0

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -1,7 +1,7 @@
 {
     "main": "lib/binding.js",
     "dependencies": {
-        "node-addon-api": "^0.3.0"
+        "node-addon-api": "^1.1.0"
     },
     "scripts": {
         "test": "node --napi-modules ./test/test_binding.js"

--- a/generators/app/templates/src/module.cc
+++ b/generators/app/templates/src/module.cc
@@ -2,39 +2,57 @@
 
 using namespace Napi;
 
-void <%= moduleClassName %>::Initialize(Napi::Env& env, Object& target) {
-    Napi::Function constructor = DefineClass(env, "<%= moduleClassName %>", {
-        InstanceMethod("greet", &<%= moduleClassName %>::Greet)
-    });
+<%= moduleClassName %>::<%= moduleClassName %>(const Napi::CallbackInfo& info) : ObjectWrap(info) {
+    Napi::Env env = info.Env();
 
-    target.Set("<%= moduleClassName %>", constructor);
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Wrong number of arguments")
+          .ThrowAsJavaScriptException();
+        return;
+    }
+
+    if (!info[0].IsString()) {
+        Napi::TypeError::New(env, "You need to name yourself")
+          .ThrowAsJavaScriptException();
+        return;
+    }
+
+    this->_greeterName = info[0].As<Napi::String>().Utf8Value();
 }
 
 Napi::Value <%= moduleClassName %>::Greet(const Napi::CallbackInfo& info) {
-    if (!info[0].IsString())
-    {
-        throw Error::New(info.Env(), "You need to introduce yourself to greet");
+    Napi::Env env = info.Env();
+
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Wrong number of arguments")
+          .ThrowAsJavaScriptException();
+        return env.Null();
     }
 
-    String name = info[0].As<String>();
+    if (!info[0].IsString()) {
+        Napi::TypeError::New(env, "You need to introduce yourself to greet")
+          .ThrowAsJavaScriptException();
+        return env.Null();
+    }
+
+    Napi::String name = info[0].As<Napi::String>();
 
     printf("Hello %s\n", name.Utf8Value().c_str());
-    printf("I am %s\n", this->_greeterName.Value().Utf8Value().c_str());
+    printf("I am %s\n", this->_greeterName.c_str());
 
-    return this->_greeterName.Value();
+    return Napi::String::New(env, this->_greeterName);
 }
 
-<%= moduleClassName %>::<%= moduleClassName %>(const Napi::CallbackInfo& info) {
-    if (!info[0].IsString())
-    {
-        throw Error::New(info.Env(), "You must name me");
-    }
-
-    this->_greeterName = Persistent(info[0].As<String>());
+Napi::Function <%= moduleClassName %>::GetClass(Napi::Env env) {
+    return DefineClass(env, "<%= moduleClassName %>", {
+        <%= moduleClassName %>::InstanceMethod("greet", &<%= moduleClassName %>::Greet),
+    });
 }
 
-void Init(Env env, Object exports, Object module) {
-    <%= moduleClassName %>::Initialize(env, exports);
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    Napi::String name = Napi::String::New(env, "<%= moduleClassName %>");
+    exports.Set(name, <%= moduleClassName %>::GetClass(env));
+    return exports;
 }
 
 NODE_API_MODULE(addon, Init)

--- a/generators/app/templates/src/module.h
+++ b/generators/app/templates/src/module.h
@@ -5,11 +5,11 @@
 class <%= moduleClassName %> : public Napi::ObjectWrap<<%= moduleClassName %>>
 {
 public:
-    static void Initialize(Napi::Env&, Napi::Object&);
-
     <%= moduleClassName %>(const Napi::CallbackInfo&);
     Napi::Value Greet(const Napi::CallbackInfo&);
 
+    static Napi::Function GetClass(Napi::Env);
+
 private:
-    Napi::Reference<Napi::String> _greeterName;
+    std::string _greeterName;
 };


### PR DESCRIPTION
I've put in some work to get this template working with latest node-addon-api. 

I changed the type of ```_greeterName``` from ```Napi::Reference<Napi::String>``` to ```std::string```. Tbh this is because I don't get it running to make a reference with persistent like in the old template. I think this could be improved. But its might be useful for developers to see a conversion between standard types and napi types in both ways.

Tests running with node-v8 (node/9.2.0/x64) / node-chakracore (chakracore/8.6.0/x64) on Linux and Windows 10. ~~With node-chakracore (chakracore/8.6.0/x64) I've a segmentation fault on my Linux (kernel 4.13.12-1) machine. The segmentation fault is caused by the second test case ```testInvalidParams()```. After test assertion is passed node is terminating with segmentation fault. I don't know if this segmentation fault is caused by changes I made. Its not reproducible with node-chakracore (chakracore/8.6.0/x64) on Windows 10.~~ Fixed: ff49f7f

Credits to https://github.com/node-ffi-napi/weak-napi/commit/eb0e5cc6d8dace93b8a4f4e3b5d3257d07171af3 and https://github.com/NickNaso/conf-ni-2017/tree/master/7-vedis-napi.